### PR TITLE
Update COTX-X1 Lite gateway

### DIFF
--- a/doc/content/gateways/COTX-X1 Lite gateway
+++ b/doc/content/gateways/COTX-X1 Lite gateway
@@ -35,7 +35,7 @@ Step 4: Finally Insert the power adapter into the 110~220VAC mains socket, conne
 After plugging in the power, If the device indicator is green, the system is running properly. The Gateway should now connect to The Things Network .
 1.3 Registering the Gateway on TTN 
 1.Create a new {{% tts %}} account or login to your previously created {{% tts %}} account.
-2.Select CONSOLE for Europe1, North America1, or Australia1.
+2.In CONSOLE, select for Europe1, North America1, or Australia1.
 ![Lite-4.png](./TTN-X1%20Lite-4.png)
 3.Select Gateways , and then select Register Gateway.
 4.Under Gateway ID, enter the 8 byte gateway ID recorded on the bottom of gateway’s label named “ID”.
@@ -44,4 +44,5 @@ After plugging in the power, If the device indicator is green, the system is run
 7.Select a frequency plan from the dropdown box that corresponds to the frequency band supported by the Gateway.
 8.The default connection of Gateway is Europe1, Gateway Server Address is: eu1.cloud.thethings.network, no additional other configuration. 
 ![Lite-5.png](./TTN-X1%20Lite-5.png)
+If you Select Area at CONSOLE(step2), the address will automatically change to the corresponding address. no additional other configuration.
 9.Click Create Gateway. 


### PR DESCRIPTION
1. add title
2. "no wrap" to "soft wrap"
3. change the image reference to, for example, "![Lite-1.png](./TTN-X1%20Lite-1.png)"
4. change the ttn to {{% tts %}}. I've not change the titles, only one change in "1.Create a new {{% tts %}} account or login to your previously created {{% tts %}} account."
5. not only europe, "2.In CONSOLE, select for Europe1, North America1, or Australia1."

wait to change:
"Inconsistent spacing". don't know what it is...

<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

...

#### Screenshots
<!-- Post a screenshot of your rendered content
NOTE: This section is optional.
-->

...

#### Changes
<!-- What are the changes made in this pull request? -->

- ...
- ...

#### Notes for Reviewers
<!--
NOTE: This section is optional.

Motivate briefly why it is implemented this way, if that deviates from the
implementation proposal in the referenced issues.
- How should your reviewers approach this pull request?
- @mention reviewers with special requests or questions for them
-->

...

#### Checklist
<!-- Make sure that this pull request is complete. -->

- [ ] Scope: The referenced issue is addressed, there are no unrelated changes.
- [ ] Run Locally: Verified that the docs build using `make server`, posted screenshots, verified external links.
- [ ] Style Guidelines: Documentation obeys style guidelines in [CONTRIBUTING](CONTRIBUTING.md).
- [ ] Commits: Commit messages follow guidelines in [CONTRIBUTING](CONTRIBUTING.md), there are no fixup commits left.
